### PR TITLE
2.0 Enable split source/build folders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,16 @@ allprojects {
     repositories {
         jcenter()
     }
+
+    // Setup the project build directories reletive to a base build
+    // directory if one is defined in, for example, a Gradle
+    // properties file.  Note that this is a "poor man's" solution and
+    // does not preserve project hierarchies.  A better solution,
+    // probably optimal, would be to provide a Gradle plugin to handle
+    // a more complete implementation.
+    if (baseBuildDir != null) {
+        buildDir = baseBuildDir + (parent == null ? "/${project.name}/build" : "/${rootProject.name}/${project.name}/build")
+    }
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
If one is defined, use a base directory to place the build artifacts for
all project modules thus allowing the project source files and build
files to be in separate directories and possbily separate file systems,
in case that matters.
